### PR TITLE
Removed obsolete fields in toml conf files

### DIFF
--- a/conf_stations/conf_bucharest_mira-parsivel.toml
+++ b/conf_stations/conf_bucharest_mira-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 220 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0 # mm ; fill with the real value
 DD_ORIENTATION = 90 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [220, 250, 280] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_bucharest_rpg94-parsivel.toml
+++ b/conf_stations/conf_bucharest_rpg94-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 150 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0 # mm ; fill with the real value
 DD_ORIENTATION = 90 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [50, 150, 300] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_galati_rpg94-parsivel.toml
+++ b/conf_stations/conf_galati_rpg94-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 150 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0 # mm ; fill with the real value
 DD_ORIENTATION = 0 # degree, from North ; fill with the real value
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [50, 150, 300] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_granada_rpg94-parsivel.toml
+++ b/conf_stations/conf_granada_rpg94-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 150 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0 # mm ; no AMS yet, fill with the real value when available
 DD_ORIENTATION = 112.5 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [50, 150, 300] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_hyytiala_rpg94-parsivel.toml
+++ b/conf_stations/conf_hyytiala_rpg94-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 175 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0 # mm ; no AMS yet, fill with the real value when available
 DD_ORIENTATION = 135 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [100, 175, 250] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_juelich_mira-parsivel.toml
+++ b/conf_stations/conf_juelich_mira-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 150 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0 # mm ; default value ; no weather available at Juelich but this value is used by the code only if weather is available
 DD_ORIENTATION = 0 # degree, from North ; fill with the real value
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [150, 200, 300] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; default value ; no weather available at Juelich but this value is used by the code only if weather is available
 MAX_WS = 10 # m/s ; default value ; no weather available at Juelich but this value is used by the code only if weather is available
 MIN_TEMP = 2 # °C ; default value ; no weather available at Juelich but this value is used by the code only if weather is available
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation ; default value ; no weather available at Juelich but this value is used by the code only if weather is available

--- a/conf_stations/conf_lampedusa_mira-thies.toml
+++ b/conf_stations/conf_lampedusa_mira-thies.toml
@@ -17,16 +17,13 @@ AU = 1009
 DD_SAMPLING_AREA_DEFAULT = 0.0046
 DD_SAMPLING_AREA = 0.0046414 # m^2 ; = SAMPLING_AREA_DEFAULT*AU/1000
 DCR_DZ_RANGE = 125 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0.01 # mm ; fill with the real value
 DD_ORIENTATION = 0 # degree, from North ; fill with the real value
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [100, 125, 150] # ; fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_lepizig_rpg94-parsivel.toml
+++ b/conf_stations/conf_lepizig_rpg94-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 135 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0.01 # mm ; fill with the real value
 DD_ORIENTATION = 0 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [105, 135, 165] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_lindenberg_mira-parsivel.toml
+++ b/conf_stations/conf_lindenberg_mira-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 200 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0.01 # mm ; fill with the real value
 DD_ORIENTATION = 0 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [150, 200, 300] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_lindenberg_mira-thies.toml
+++ b/conf_stations/conf_lindenberg_mira-thies.toml
@@ -17,16 +17,13 @@ AU = 1009
 DD_SAMPLING_AREA_DEFAULT = 0.0046
 DD_SAMPLING_AREA = 0.0046414 # m^2 ; = SAMPLING_AREA_DEFAULT*AU/1000
 DCR_DZ_RANGE = 200 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0.01 # mm ; fill with the real value
 DD_ORIENTATION = 90 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [150, 200, 300] # ; fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_lindenberg_rpg94-parsivel.toml
+++ b/conf_stations/conf_lindenberg_rpg94-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 120 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0.01 # mm ; fill with the real value
 DD_ORIENTATION = 0 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [120, 180, 240] # fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_lindenberg_rpg94-thies.toml
+++ b/conf_stations/conf_lindenberg_rpg94-thies.toml
@@ -17,16 +17,13 @@ AU = 1009
 DD_SAMPLING_AREA_DEFAULT = 0.0046
 DD_SAMPLING_AREA = 0.0046414 # m^2 ; = SAMPLING_AREA_DEFAULT*AU/1000
 DCR_DZ_RANGE = 120 # m ; height at which to compute Delta Z ; fill with the real value
-RAIN_GAUGE_SAMPLING = 0.01 # mm ; fill with the real value
 DD_ORIENTATION = 90 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [120, 180, 240] # ; fill with the good values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_munich_mira-parsivel.toml
+++ b/conf_stations/conf_munich_mira-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 200 # m ; height at which to compute Delta Z # TODO : set a suited value
-RAIN_GAUGE_SAMPLING = 0.01 # mm ; fill with the real value
 DD_ORIENTATION = 0 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [150, 200, 300] # TODO : set suited values
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation ; default value

--- a/conf_stations/conf_palaiseau_basta-parsivel.toml
+++ b/conf_stations/conf_palaiseau_basta-parsivel.toml
@@ -15,16 +15,13 @@ MAX_ALTITUDE_RADAR_DATA = 2500
 [instrument_parameters]
 DD_SAMPLING_AREA = 0.0054 # m^2 ; Parsivel2 sampling surface
 DCR_DZ_RANGE = 300 # m ; height at which to compute Delta Z
-RAIN_GAUGE_SAMPLING = 0.2 # mm
 DD_ORIENTATION = 0 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [100, 200, 300]
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation

--- a/conf_stations/conf_palaiseau_basta-thies.toml
+++ b/conf_stations/conf_palaiseau_basta-thies.toml
@@ -17,16 +17,13 @@ AU = 965
 DD_SAMPLING_AREA_DEFAULT = 0.0046
 DD_SAMPLING_AREA = 0.004439 # m^2 ; = SAMPLING_AREA_DEFAULT*AU/1000
 DCR_DZ_RANGE = 300 # m ; height at which to compute Delta Z
-RAIN_GAUGE_SAMPLING = 0.2 # mm
 DD_ORIENTATION = 0 # degree, from North
 
 [plot_parameters]
-DCR_PLOTTED_RANGES = [100, 200, 300]
 
 [thresholds]
 MAX_RR = 3  # mm/h
 MIN_RAINFALL_AMOUNT = 3 # mm/episode
-MAX_MEAN_WS = 7 # m/s ; maximum average wind over a "good" event
 MAX_WS = 10 # m/s ; max wind to keep a timestep
 MIN_TEMP = 2 # °C
 MIN_HUR = 80 # min relative humidity : avoid cases with evaporation


### PR DESCRIPTION
removed RAIN_GAUGE_SAMPLING (not useful), DCR_PLOTTED_RANGES (only one gate is plotted for DCR data in daily quicklooks now, the one specified by DCR_DZ_RANGE) and MAX_MEAN_WS (flag on average wind over the event is not used anymore) from all config files